### PR TITLE
Fix sidebar links

### DIFF
--- a/webapp/src/components/Sidebar/Sidebar.jsx
+++ b/webapp/src/components/Sidebar/Sidebar.jsx
@@ -355,10 +355,6 @@ class Sidebar extends React.Component {
         </Hidden>
         <Hidden smDown>
           <Drawer
-            onMouseOver={() => this.setState({ miniActive: false })}
-            onFocus={() => this.setState({ miniActive: false })}
-            onMouseOut={() => this.setState({ miniActive: true })}
-            onBlur={() => this.setState({ miniActive: true })}
             anchor={rtlActive ? 'right' : 'left'}
             variant="permanent"
             open


### PR DESCRIPTION
Mouse event handlers on the Drawer component were calling setState and causing infinite re-render loop when component was hovered over. This prevented Collapse component from expanding.

Fixes #24 